### PR TITLE
Comment out export-cad and println statements

### DIFF
--- a/design-generator.stanza
+++ b/design-generator.stanza
@@ -12,11 +12,11 @@ pcb-module my-design :
 make-default-board(my-design, 4, Rectangle(25.0, 10.0))
 
 ; Export CAD with default options
-export-cad()
+; export-cad()
 
 ; Show the Schematic and PCB for the design
 view-board()
 view-schematic()
 
 ; Print the MPN of the resistor from the design
-println(mpn?(my-design.r))
+; println(mpn?(my-design.r))


### PR DESCRIPTION
Comment out export-cad and println statements to make design template not add any persistence on first use