### PR TITLE
Remove ocdb subsubmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "open-components-database"]
-	path = open-components-database
-	url = https://github.com/JITx-Inc/open-components-database.git
-	branch = master


### PR DESCRIPTION
This is a deprecated duplicate of ocdb. The create-project feature uses jitx-client/open-components-database submodule commit