### PR TITLE
Move Toleranced to jitx package

### DIFF
--- a/design-generator.stanza
+++ b/design-generator.stanza
@@ -6,7 +6,6 @@ defpackage design-template :
   import jitx/commands
   import ocdb/utils/checks
   import ocdb/utils/generic-components
-  import ocdb/utils/tolerance
 
 ; ==========================================
 ; Implement other modules used by our design 


### PR DESCRIPTION
Remove `import ocdb/utils/tolerance`. Toleranced is now defined in `jitx` package.