### PR TITLE
Add view-design-explorer() to design-template

### DIFF
--- a/design-generator.stanza
+++ b/design-generator.stanza
@@ -36,7 +36,8 @@ defn run-design (circuit:Instantiable, run-checks?:True|False) :
   
   if run-checks? :
     run-checks("checks.txt")
-  else:  
+  else:
+    view-design-explorer()
     view-board()
     view-schematic()
 


### PR DESCRIPTION
I believe `view-design-explorer()` does not add any noticeable extra time, so I am putting it before `view-board` / `view-schematic()`