### PR TITLE
JITX-6112/bom-set-design-board-rules

### DIFF
--- a/helpers.stanza
+++ b/helpers.stanza
@@ -10,20 +10,22 @@ defpackage helpers :
   import ocdb/utils/checks
   import ocdb/utils/generic-components
 
-; ==============
-; Initialization
-; ==============
-public defn initalize-helpers () :
-  set-bom-vendors(ocdb/utils/design-vars/APPROVED-DISTRIBUTOR-LIST)
-  set-bom-design-quantity(ocdb/utils/design-vars/DESIGN-QUANTITY)
-
 ; ============
 ; setup-design
 ; ============
-public defn setup-design (name:String, board:Board, -- rules:Rules|False = false) :
+public defn setup-design (name:String, board:Board
+                          --
+                          rules:Rules|False = false
+                          vendors:Tuple<String|AuthorizedVendor>|False = false
+                          quantity:Int|False = false) :
   set-current-design(name)
   set-board(board)
-  match(rules:Rules) : set-rules(rules)
+  set-rules $ match(rules:Rules) : rules
+  else : ocdb/utils/defaults/default-rules
+  set-bom-vendors $ match(vendors:Tuple<String|AuthorizedVendor>) : vendors
+  else : ocdb/utils/design-vars/APPROVED-DISTRIBUTOR-LIST
+  set-bom-design-quantity $ match(quantity:Int) : quantity
+  else : ocdb/utils/design-vars/DESIGN-QUANTITY
 
 ; =====================
 ; Run the design checks

--- a/helpers.stanza
+++ b/helpers.stanza
@@ -1,5 +1,5 @@
 ; ====================
-; A number of helpful functions to check your designs, export to CAD, 
+; A number of helpful functions to check your designs, export to CAD,
 ; update your design in CAD, etc.
 ; ====================
 #use-added-syntax(jitx)
@@ -9,6 +9,21 @@ defpackage helpers :
   import jitx/commands
   import ocdb/utils/checks
   import ocdb/utils/generic-components
+
+; ==============
+; Initialization
+; ==============
+public defn initalize-helpers () :
+  set-bom-vendors(ocdb/utils/design-vars/APPROVED-DISTRIBUTOR-LIST)
+  set-bom-design-quantity(ocdb/utils/design-vars/DESIGN-QUANTITY)
+
+; ============
+; setup-design
+; ============
+public defn setup-design (name:String, board:Board, -- rules:Rules|False = false) :
+  set-current-design(name)
+  set-board(board)
+  match(rules:Rules) : set-rules(rules)
 
 ; =====================
 ; Run the design checks
@@ -44,6 +59,4 @@ public defn update-design () :
 ; Export BOM to tsv
 ; =================
 public defn export-bill-of-materials () :
-  set-bom-vendors(ocdb/utils/design-vars/APPROVED-DISTRIBUTOR-LIST)
-  set-bom-design-quantity(ocdb/utils/design-vars/DESIGN-QUANTITY)
   export-bom()

--- a/helpers.stanza
+++ b/helpers.stanza
@@ -15,17 +15,14 @@ defpackage helpers :
 ; ============
 public defn setup-design (name:String, board:Board
                           --
-                          rules:Rules|False = false
-                          vendors:Tuple<String|AuthorizedVendor>|False = false
-                          quantity:Int|False = false) :
+                          rules:Rules = ocdb/utils/defaults/default-rules
+                          vendors:Tuple<String|AuthorizedVendor> = ocdb/utils/design-vars/APPROVED-DISTRIBUTOR-LIST
+                          quantity:Int = ocdb/utils/design-vars/DESIGN-QUANTITY) :
   set-current-design(name)
   set-board(board)
-  set-rules $ match(rules:Rules) : rules
-  else : ocdb/utils/defaults/default-rules
-  set-bom-vendors $ match(vendors:Tuple<String|AuthorizedVendor>) : vendors
-  else : ocdb/utils/design-vars/APPROVED-DISTRIBUTOR-LIST
-  set-bom-design-quantity $ match(quantity:Int) : quantity
-  else : ocdb/utils/design-vars/DESIGN-QUANTITY
+  set-rules(rules)
+  set-bom-vendors(vendors)
+  set-bom-design-quantity(quantity)
 
 ; =====================
 ; Run the design checks

--- a/main.stanza
+++ b/main.stanza
@@ -7,9 +7,6 @@ defpackage main :
   import ocdb/utils/generic-components
   import helpers
 
-; Initialization
-initalize-helpers()
-
 ; Define the shape/size of the board
 val board-shape = RoundedRectangle(30.0, 18.5, 0.25)
 
@@ -27,13 +24,14 @@ pcb-module my-design :
   inst version-label  : ocdb/artwork/board-text/version-silkscreen("Version 0.0")
   place(version-label) at loc(0.0, height(board-shape) / 2.0 - 1.0) on Bottom
 
-; Set the design name  - a directory with this name will be generated under the "designs" directory
-;     the board        - a Board object
-;     [optional] rules - the PCB design rules
+; Set the design name     - a directory with this name will be generated under the "designs" directory
+;     the board           - a Board object
+;     [optional] rules    - the PCB design rules (if not givn default rules will be used)
+;     [optional] vendors  - Strings or AuthorizedVendors (if not give default vendors will be used)
+;     [optional] quantity - Minimum stock quantity the vendor should carry (if not give default quantity will be used)
 setup-design(
   "jitx-design",
-  ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, board-shape),
-  rules = ocdb/manufacturers/rules/jlcpcb-rules
+  ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, board-shape)
 )
 
 ; Set the schematic sheet size

--- a/main.stanza
+++ b/main.stanza
@@ -7,13 +7,11 @@ defpackage main :
   import ocdb/utils/generic-components
   import helpers
 
+; Initialization
+initalize-helpers()
+
 ; Define the shape/size of the board
 val board-shape = RoundedRectangle(30.0, 18.5, 0.25)
-
-; Setup the board
-defn setup-board () :
-  set-board(ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, board-shape))
-  set-rules(ocdb/manufacturers/rules/jlcpcb-rules)
 
 ; Module to run as a design
 pcb-module my-design :
@@ -29,14 +27,17 @@ pcb-module my-design :
   inst version-label  : ocdb/artwork/board-text/version-silkscreen("Version 0.0")
   place(version-label) at loc(0.0, height(board-shape) / 2.0 - 1.0) on Bottom
 
-; Set the design name - a directory with this name will be generated under the "designs" directory
-set-current-design("jitx-design")
+; Set the design name  - a directory with this name will be generated under the "designs" directory
+;     the board        - a Board object
+;     [optional] rules - the PCB design rules
+setup-design(
+  "jitx-design",
+  ocdb/utils/defaults/default-board(ocdb/manufacturers/stackups/jlcpcb-jlc2313, board-shape),
+  rules = ocdb/manufacturers/rules/jlcpcb-rules
+)
 
 ; Set the schematic sheet size
 set-paper(ANSI-A)
-
-; Setup the board properties
-setup-board()
 
 ; Set the top level module (the module to be compile into a schematic and PCB)
 set-main-module(my-design)


### PR DESCRIPTION
### Changes

* move up `set-bom-vendors` and fix the sequence of `set-current-design`, `set-board`, and `set-rules`.