### PR TITLE
JITX-7019/update-for-BOM-Columns-set-export-backend-do-not-populate-version-label-view-bom

### DIFF
--- a/helpers.stanza
+++ b/helpers.stanza
@@ -17,12 +17,16 @@ public defn setup-design (name:String, board:Board
                           --
                           rules:Rules = ocdb/utils/defaults/default-rules
                           vendors:Tuple<String|AuthorizedVendor> = ocdb/utils/design-vars/APPROVED-DISTRIBUTOR-LIST
-                          quantity:Int = ocdb/utils/design-vars/DESIGN-QUANTITY) :
+                          quantity:Int = ocdb/utils/design-vars/DESIGN-QUANTITY
+                          bom-columns:Tuple<BOMColumn> = ocdb/utils/design-vars/BOM-COLUMNS) :
   set-current-design(name)
   set-board(board)
   set-rules(rules)
   set-bom-vendors(vendors)
   set-bom-design-quantity(quantity)
+  set-bom-columns(bom-columns)
+  set-paper(ANSI-A4)
+  set-export-backend(`altium) ; set the CAD software for export to be altium (also supported: `kicad)
 
 ; =====================
 ; Run the design checks
@@ -36,8 +40,6 @@ public defn run-check-on-design (circuit:Instantiable) :
 ; Actual Export design
 ; ====================
 public defn export-to-cad () :
-  set-paper(ANSI-A4)
-  set-export-backend(`altium) ; set the CAD software for export to be altium (also supported: `kicad)
   export-cad([
     "vendor_part_numbers.lcsc" => "LCSC"
   ])

--- a/main.stanza
+++ b/main.stanza
@@ -23,6 +23,7 @@ pcb-module my-design :
   ; Write the board version on silkscreen
   inst version-label  : ocdb/artwork/board-text/version-silkscreen("Version 0.0")
   place(version-label) at loc(0.0, height(board-shape) / 2.0 - 1.0) on Bottom
+  do-not-populate(version-label)
 
 ; Set the design name     - a directory with this name will be generated under the "designs" directory
 ;     the board           - a Board object
@@ -47,3 +48,4 @@ set-main-module(my-design)
 view-board()
 view-schematic()
 view-design-explorer()
+view-bom(BOM-STD)


### PR DESCRIPTION
update for :
* BOMColumns
* set-export-backend
* do-not-populate(version-label)
* view-bom(BOM-STD)
* set-paper