### PR TITLE
Removed extraneous lines added for slm integration

### DIFF
--- a/board.stanza
+++ b/board.stanza
@@ -8,6 +8,8 @@ defpackage board :
   import jitx/commands
   import jitx/parts
 
+  import jsl
+
 
 public defn setup-my-board (outline:Shape) :
   set-board(this-board(outline))
@@ -15,7 +17,7 @@ public defn setup-my-board (outline:Shape) :
 
 ; Creates a pcb-board with a typical JLCPCB stackup given board outline.
 public pcb-board this-board (outline:Shape) :
-  stackup = jlc-pcb/stackups/JLC04161H-7628/stackup
+  stackup = create-pcb-stackup(jlc-pcb/stackups/JLC04161H-7628/stackup-gen)
   boundary = outline
   signal-boundary = outline
   vias = [jlc-pcb/stackups/vias/std-via-preferred]

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,5 +1,3 @@
-include? ".slm/stanza.proj"
-pkg-cache: ".slm/pkg-cache"
 
 package main defined-in "main.stanza"
 package board defined-in "board.stanza"


### PR DESCRIPTION
Previous attempt to purge slm failed because these lines caused new project run to fail because of duplicate lines introduced by `slm init` in the launcher.