### PR TITLE
Modify capacitor tolerance

### DIFF
--- a/helpers.stanza
+++ b/helpers.stanza
@@ -46,7 +46,7 @@ public defn setup-part-query (
     all-cats,
     type = "ceramic",
     temperature-coefficient_code = ["X7R", "X5R"],
-    precision = (10 %),
+    tolerance_max = 0.2,
     rated-voltage = AtLeast(6.0)
   )
   set-default-capacitor-query!(C-query)


### PR DESCRIPTION
By default, look for capacitors with tolerance up to 20% (e.g. 5%, 10%, 20%), and not only 10%.

This resolves part queries returning much larger size capacitors than expected.